### PR TITLE
Fix learning rate scheduler parameters

### DIFF
--- a/examples/pretraining/configs/Doge-160M.yaml
+++ b/examples/pretraining/configs/Doge-160M.yaml
@@ -55,9 +55,9 @@ lr_scheduler_type: warmup_stable_decay
 lr_scheduler_kwargs:
   warmup_type: linear
   decay_type: linear
-  decay_ratio: 0.1
+  decay_steps: 2400
   min_lr_ratio: 0.0
-warmup_ratio: 0.1
+warmup_steps: 2400
 weight_decay: 0.01
 gradient_accumulation_steps: 768
 max_grad_norm: 1.0

--- a/examples/pretraining/configs/Doge-20M.yaml
+++ b/examples/pretraining/configs/Doge-20M.yaml
@@ -55,9 +55,9 @@ lr_scheduler_type: warmup_stable_decay
 lr_scheduler_kwargs:
   warmup_type: linear
   decay_type: linear
-  decay_ratio: 0.1
+  decay_steps: 800
   min_lr_ratio: 0.0
-warmup_ratio: 0.1
+warmup_steps: 800
 weight_decay: 0.01
 gradient_accumulation_steps: 256
 max_grad_norm: 1.0

--- a/examples/pretraining/configs/Doge-320M.yaml
+++ b/examples/pretraining/configs/Doge-320M.yaml
@@ -55,9 +55,9 @@ lr_scheduler_type: warmup_stable_decay
 lr_scheduler_kwargs:
   warmup_type: linear
   decay_type: linear
-  decay_ratio: 0.1
+  decay_steps: 3200
   min_lr_ratio: 0.0
-warmup_ratio: 0.1
+warmup_steps: 3200
 weight_decay: 0.01
 gradient_accumulation_steps: 1024
 max_grad_norm: 1.0

--- a/examples/pretraining/configs/Doge-60M.yaml
+++ b/examples/pretraining/configs/Doge-60M.yaml
@@ -55,9 +55,9 @@ lr_scheduler_type: warmup_stable_decay
 lr_scheduler_kwargs:
   warmup_type: linear
   decay_type: linear
-  decay_ratio: 0.1
+  decay_steps: 1600
   min_lr_ratio: 0.0
-warmup_ratio: 0.1
+warmup_steps: 1600
 weight_decay: 0.01
 gradient_accumulation_steps: 512
 max_grad_norm: 1.0

--- a/examples/pretraining/configs/Doge-MoE-20M.yaml
+++ b/examples/pretraining/configs/Doge-MoE-20M.yaml
@@ -60,9 +60,9 @@ lr_scheduler_type: warmup_stable_decay
 lr_scheduler_kwargs:
   warmup_type: linear
   decay_type: linear
-  decay_ratio: 0.1
+  decay_steps: 800
   min_lr_ratio: 0.0
-warmup_ratio: 0.1
+warmup_steps: 800
 weight_decay: 0.01
 gradient_accumulation_steps: 256
 max_grad_norm: 1.0

--- a/examples/pretraining/configs/Doge-MoE-220M.yaml
+++ b/examples/pretraining/configs/Doge-MoE-220M.yaml
@@ -60,9 +60,9 @@ lr_scheduler_type: warmup_stable_decay
 lr_scheduler_kwargs:
   warmup_type: linear
   decay_type: linear
-  decay_ratio: 0.1
+  decay_steps: 2400
   min_lr_ratio: 0.0
-warmup_ratio: 0.1
+warmup_steps: 2400
 weight_decay: 0.01
 gradient_accumulation_steps: 768
 max_grad_norm: 1.0

--- a/examples/pretraining/configs/Doge-MoE-500M.yaml
+++ b/examples/pretraining/configs/Doge-MoE-500M.yaml
@@ -60,9 +60,9 @@ lr_scheduler_type: warmup_stable_decay
 lr_scheduler_kwargs:
   warmup_type: linear
   decay_type: linear
-  decay_ratio: 0.1
+  decay_steps: 3200
   min_lr_ratio: 0.0
-warmup_ratio: 0.1
+warmup_steps: 3200
 weight_decay: 0.01
 gradient_accumulation_steps: 1024
 max_grad_norm: 1.0

--- a/examples/pretraining/configs/Doge-MoE-80M.yaml
+++ b/examples/pretraining/configs/Doge-MoE-80M.yaml
@@ -60,9 +60,9 @@ lr_scheduler_type: warmup_stable_decay
 lr_scheduler_kwargs:
   warmup_type: linear
   decay_type: linear
-  decay_ratio: 0.1
+  decay_steps: 1600
   min_lr_ratio: 0.0
-warmup_ratio: 0.1
+warmup_steps: 1600
 weight_decay: 0.01
 gradient_accumulation_steps: 512
 max_grad_norm: 1.0


### PR DESCRIPTION
Adjust the learning rate scheduler configuration by replacing `decay_ratio` and `warmup_ratio` with `decay_steps` and `warmup_steps` for improved performance.